### PR TITLE
🐛 fix: correctly hand over custom filters

### DIFF
--- a/src/Elements/index.js
+++ b/src/Elements/index.js
@@ -38,7 +38,7 @@ const Elements = forwardRef(({
         return;
       }
 
-      elementsRef.current = await factory.autoCreate(filters);
+      elementsRef.current = await factory.autoCreate({ filters });
 
       if (!mounted) {
         // the component has been unmounted before elements were created

--- a/src/Elements/index.test.js
+++ b/src/Elements/index.test.js
@@ -26,14 +26,14 @@ describe('<Elements />', () => {
   });
 
   it('should create elements with custom filters', () => {
-    const filters = ['test'];
+    const opts = { filters: ['test'] };
     const autoCreate = jest.fn();
 
     render(withEngage(
-      <Elements filters={filters} />,
+      <Elements filters={opts.filters} />,
       { factory: { autoCreate } }
     ));
-    expect(autoCreate).toHaveBeenCalledWith(filters);
+    expect(autoCreate).toHaveBeenCalledWith(opts);
   });
 
   it('should override configuration', () => {


### PR DESCRIPTION
`<Elements /> `'s `filters` prop was not correctly handed over to SDK.

Spotted by @defless 🙏